### PR TITLE
Fix folder name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To compile this project, you will need to follow these steps:
 
 1. Copy everything in the ``Kerbal Space Program 2\KSP2_x64_Data\Managed`` folder into the ``external_dlls/`` folder.
 2. Run one of the build scripts and copy the contents from the build to the KSP2 root directory.
-3. Launch KSP2 and wait until the title screen appears. You should see a mods folder under the `KSP2_X64_data` folder.
+3. Launch KSP2 and wait until the title screen appears. You should see a mods folder under the `SpaceWarp` folder.
 4. Drag any mods that follow the structure below into that mods folder.
 
 Mods are currently implemented as monobehaviours with two fields: a `Logger` for logging and a `Manager` that points to Spacewarp. A mod template generator exists as a Python script.


### PR DESCRIPTION
The README suggests that the `Mods` directory is created under `KSP2_X64_data`, but I think it is created under `SpaceWarp`, right?