### PR TITLE
Fix ModTemplateGenerator's assembly references

### DIFF
--- a/ModTemplateGenerator.py
+++ b/ModTemplateGenerator.py
@@ -291,7 +291,7 @@ with open(f"{mod_id}/{mod_id_title}/{mod_id_title}.csproj", "w") as csproj:
 
     for ref in refs:
         element = root.createElement("Reference")
-        element.setAttribute("Include", ref[0])
+        element.setAttribute("Include", ref)
         itemGroup.appendChild(element)
 
     xml_str = root.toprettyxml(indent="  ")


### PR DESCRIPTION
Currently, the ModTemplateGenerator generates a list of includes where the path is `.`. This is because the relevant code path grabs the first index of the string.

Regression from commit f0710ef which refactored some of the .csproj assembly generation code.