### PR TITLE
Add defaults for certain modinfo.json fields

### DIFF
--- a/SpaceWarp/API/Configuration/ModInfo.cs
+++ b/SpaceWarp/API/Configuration/ModInfo.cs
@@ -26,10 +26,10 @@ namespace SpaceWarp.API.Configuration
         [JsonProperty("version")] 
         public string version { get; set; }
 
-        [JsonProperty("dependencies")] 
-        public List<DependencyInfo> dependencies { get; set; }
+        [JsonProperty("dependencies")]
+        public List<DependencyInfo> dependencies { get; set; } = new List<DependencyInfo>();
 
-        [JsonProperty("ksp2_version")] 
-        public SupportedVersionsInfo supported_ksp2_versions { get; set; }
+        [JsonProperty("ksp2_version")]
+        public SupportedVersionsInfo supported_ksp2_versions { get; set; } = new SupportedVersionsInfo();
     }
 }

--- a/SpaceWarp/API/Configuration/SupportedVersionsInfo.cs
+++ b/SpaceWarp/API/Configuration/SupportedVersionsInfo.cs
@@ -8,10 +8,10 @@ namespace SpaceWarp.API.Configuration
     [JsonObject(MemberSerialization.OptIn)]
     public class SupportedVersionsInfo
     {
-        [JsonProperty("min")] 
-        public string min { get; set; }
+        [JsonProperty("min")]
+        public string min { get; set; } = "0.0.0";
 
-        [JsonProperty("max")] 
-        public string max { get; set; }
+        [JsonProperty("max")]
+        public string max { get; set; } = "*";
     }
 }


### PR DESCRIPTION
This adds default values for the dependencies and KSP2 versions so that the mod can still load if they are omitted from modinfo.json.