### PR TITLE
SpaceWarp BepInEx integration

### DIFF
--- a/SpaceWarp/Entrypoint.cs
+++ b/SpaceWarp/Entrypoint.cs
@@ -1,48 +1,27 @@
+using BepInEx;
 using HarmonyLib;
 using KSP.Logging;
 using SpaceWarp.UI;
 using System.Reflection;
-using UnityEngine.SceneManagement;
 
-namespace Doorstop
+namespace SpaceWarp
 {
-    public class Entrypoint
+    static class Package
     {
-        private static bool _patched;
-     
-        private const string HARMONY_PACKAGE_URL = "com.github.x606.spacewarp";
-        
-        /// <summary>
-        /// EntryPoint for Spacewarp, called from Doorstop
-        /// </summary>
-        public static void Start()
-        {
-            SceneManager.sceneLoaded += OnSceneLoaded;
+        public const string URL = "com.github.x606.spacewarp";
+        public const string NAME = "SpaceWarp";
+        public const string VERSION = "0.1.1";
+    }
 
+    [BepInPlugin(Package.URL, Package.NAME, Package.VERSION)]
+    public class SpaceWarpEntrypoint : BaseUnityPlugin
+    {
+        private void Awake()
+        {
+            Harmony.CreateAndPatchAll(Assembly.GetExecutingAssembly());
             KspLogManager.AddLogCallback(SpaceWarpConsoleLogListener.LogCallback);
-        }
 
-        /// <summary>
-        /// Add OnGameStarted as postfix to StartGame
-        /// </summary>
-        static void OnSceneLoaded(Scene unused1, LoadSceneMode unused2)
-        {
-            if (!_patched)
-            {
-                InitializePatches();
-                _patched = true;
-            }
-        }
-
-        /// <summary>
-        /// Initializes Harmony
-        /// </summary>
-
-        static void InitializePatches()
-        {
-            Harmony harmony = new Harmony(HARMONY_PACKAGE_URL);
-
-            harmony.PatchAll(Assembly.GetExecutingAssembly());
+            Logger.LogInfo($"Plugin {Package.NAME} is loaded!");
         }
     }
 }

--- a/SpaceWarp/SpaceWarp.csproj
+++ b/SpaceWarp/SpaceWarp.csproj
@@ -38,6 +38,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\external_dlls\Assembly-CSharp.dll</HintPath>
     </Reference>
+    <Reference Include="BepInEx">
+      <HintPath>..\external_dlls\BepInEx.dll</HintPath>
+    </Reference>
     <Reference Include="Mono.Cecil, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
       <HintPath>..\packages\Mono.Cecil.0.11.4\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>


### PR DESCRIPTION
Would you consider allowing SpaceWarp to be loaded through BepInEx such as in the example pull request, so that mods using both loaders can be injected into the game?

Tested it with all the SpaceWarp mods from Spacedock in the <KSP Root>/SpaceWarp/Mods folder and everything was working in order. All this does is delegate the Doorstop injection from SpaceWarp to BepInEx so there should be no issues.